### PR TITLE
Sha256 fix

### DIFF
--- a/spy.rb
+++ b/spy.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Spy < Formula
   homepage 'https://bitbucket.org/ssaasen/spy'
   url 'https://bitbucket.org/ssaasen/spy/downloads/spy-osx-x86_64-v0.12.tar.gz'
-  sha1 '978d321f2f9956dc836b75bd4d552205798e3cf0'
+  sha256 '84197708bd771f87d8b792b3c0f2178852065f101b5fc4195dcfcec88f1676b4'
   version '0.12'
 
   def install

--- a/stash-commit-graph-reader.rb
+++ b/stash-commit-graph-reader.rb
@@ -3,7 +3,7 @@ require 'formula'
 class StashCommitGraphReader < Formula
   homepage 'https://bitbucket.org/ssaasen/stash-commit-graph-reader'
   url 'https://bitbucket.org/ssaasen/stash-commit-graph-reader/downloads/stash-commit-graph-reader-0.3.tar.gz'
-  sha1 'cae1fec162730f20cbb75d7c6ec8e8b940b72d86'
+  sha256 '5fa62bcda10b76e676899fc82901302b273451c91e7f8a883776e6779faf01a8'
   version '0.3'
 
   def install

--- a/stash-logparser.rb
+++ b/stash-logparser.rb
@@ -3,7 +3,7 @@ require 'formula'
 class StashLogparser < Formula
   homepage 'https://bitbucket.org/ssaasen/stash-log-parser'
   url 'https://bitbucket.org/ssaasen/stash-log-parser/downloads/logparser-osx-x86_64-v3.0.tar.gz'
-  sha1 '7ffde894eedf0c0a2aecf21ab20e9a0478d2ecd7'
+  sha256 'ffa942001c4fa3d8d237e5f0976ecd1aa944755c7bde9fb3d8c04e7e3d2476ed'
   version '3.0'
 
   def install


### PR DESCRIPTION
Homebrew has apparently deprecated the SHA1 hash in favor of SHA256. This should fix brew doctor from throwing warnings.
